### PR TITLE
Fixed PackageRoot relative path to External\Packages

### DIFF
--- a/Build/Common.Build.settings
+++ b/Build/Common.Build.settings
@@ -44,7 +44,7 @@
     <WebsocketppIncludeDir>$(BuildRoot)\Release\libs\websocketpp</WebsocketppIncludeDir>
     <PackagesRoot Condition="'$(PackagesRoot)'=='' AND Exists('$(BuildRoot)\packages')">$(BuildRoot)\packages</PackagesRoot>
     <PackagesRoot Condition="'$(PackagesRoot)'=='' AND Exists('$(BuildRoot)\..\Tools\packages')">$(BuildRoot)\..\Tools\packages</PackagesRoot>
-    <PackagesRoot Condition="'$(PackagesRoot)'=='' AND Exists('$(BuildRoot)\..\External\Packages')">$(BuildRoot)\..\External\Packages</PackagesRoot>
+    <PackagesRoot Condition="'$(PackagesRoot)'=='' AND Exists('$(BuildRoot)\..\..\External\Packages')">$(BuildRoot)\..\..\External\Packages</PackagesRoot>
     <CollateralsDir>$(BuildRoot)\Release\Collateral</CollateralsDir>
   </PropertyGroup>
 

--- a/Release/src/build/vs14.static/casablanca140.static.vcxproj
+++ b/Release/src/build/vs14.static/casablanca140.static.vcxproj
@@ -44,7 +44,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_ASYNCRT_EXPORT;_PPLX_EXPORT;WIN32;_MBCS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(CasablancaIncludeDir);$(CasablancaSrcDir)\pch;$(WebsocketppIncludeDir);..\..\..\..\..\Packages\boost.1.58.0.0\lib\native\include;..\..\..\..\..\Packages\openssl.v140.windesktop.msvcstl.static.rt-dyn.x86.1.0.2.0\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(CasablancaIncludeDir);$(CasablancaSrcDir)\pch;$(WebsocketppIncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalOptions>-Zm300 /bigobj %(AdditionalOptions)</AdditionalOptions>


### PR DESCRIPTION
This fixes the sdk not building in certain configurations when included from the Xbox Live SDK.

The change to the project file removes manual includes that are no longer needed now the package root is setup correctly.